### PR TITLE
Fix adding content in palette list-property-inspector does not reveal the added content, it looks like theres no effect

### DIFF
--- a/ui/inspector/blueprint/property-value-type/list-property-inspector.reel/list-property-inspector.js
+++ b/ui/inspector/blueprint/property-value-type/list-property-inspector.reel/list-property-inspector.js
@@ -42,6 +42,11 @@ exports.ListPropertyInspector = Montage.create(ValueTypeInspector, /** @lends mo
         value: function (evt) {
             if (!this.objectValue) {
                 this.objectValue = new Array();
+                // The collectionValue property is basically a wrapper around the
+                // objectValue, this is why we need to manually dispatch a
+                // collectionValue change, otherwise the observers will not now
+                // that this property has changed as a consequence.
+                this.dispatchOwnPropertyChange("collectionValue", this.objectValue);
             }
             this.collectionValue.add("");
         }


### PR DESCRIPTION
Since collectionValue in ListPropertyInspector is just a wrapper around objectValue we need to manually dispatch a collectionValue change whenever objectValue is assigned a new object.
