### PR TITLE
Set the iFrame base href to the loaded template URL. And set the charset to UTF-8 by default

### DIFF
--- a/ui/editing-frame.reel/editing-frame.js
+++ b/ui/editing-frame.reel/editing-frame.js
@@ -331,6 +331,16 @@ exports.EditingFrame = Montage.create(Component, /** @lends module:"montage/ui/e
 
                 frameWindow.name = "editingFrame=" + packageRequire.location;
 
+                var frameDocument = frame.contentDocument,
+                    frameHead = frameDocument.getElementsByTagName("head")[0],
+                    baseElem = frameDocument.createElement("base"),
+                    metaElem = frameDocument.createElement("meta");
+
+                baseElem.setAttribute("href", template._baseUrl);
+                metaElem.setAttribute("charset", "utf-8");
+                frameHead.insertBefore(metaElem, null);
+                frameHead.insertBefore(baseElem, metaElem);
+
                 // We need to boot Montage in the frame so that all the shims
                 // Montage needs get installed
                 if (self.iframe.src !== "" || !frameWindow.montageRequire) {


### PR DESCRIPTION
As a component is loaded on the stage by injection into a dynamic iFrame, we need to set the base url of the iFrame, else the component's relative URLs wont be correctly resolved.

This patch also set the charset for the iFrame to UTF-8. Ideally we should retrieve the charset from the component's header (as well any other headers's meta). But for now, that should be better than doing nothing.
