### PR TITLE
Fix issue with the select in the num property inspector

### DIFF
--- a/ui/inspector/blueprint/property-value-type/enum-property-inspector.reel/enum-property-inspector.html
+++ b/ui/inspector/blueprint/property-value-type/enum-property-inspector.reel/enum-property-inspector.html
@@ -91,11 +91,11 @@
                 }
             },
             "bindings":{
-                "selection":{
-                    "<->":"@owner.objectValue"
-                },
                 "content":{
-                    "<-":"@owner.propertyBlueprint.enumValues"
+                    "<-":"@owner.propertyBlueprint.enumValues.map{{value: this}}"
+                },
+                "value":{
+                    "<->": "@owner.objectValue"
                 }
             }
         }


### PR DESCRIPTION
There were two problems:
- The value selected in the select wasn't being saved

This was an issue with the shape of the data we're giving to the select, it needs to be an array of objects, not an array of strings to show in the select.
- On load it wouldn't select the current value to show.

This is an issue related to the order of the bindings, and using the wrong property.
The select doesn't have a selection property, it's the value property and it can only be set after the content is set otherwise the select doesn't recognize that value.
This is a big issue, as it is, I believe it will always work when creating this in lumieres just because "content" comes before "value" in alphabetical order.
