### PR TITLE
tooltip showing entire path on bindings

### DIFF
--- a/ui/inspector/blueprint/bound-property-editor.reel/bound-property-editor.html
+++ b/ui/inspector/blueprint/bound-property-editor.reel/bound-property-editor.html
@@ -98,7 +98,12 @@
                         "@": "owner"
                     }
                 }
-            ]
+            ],
+            "bindings": {
+                "title": {
+                    "<-": "@owner.binding.sourcePath"
+                }
+            }
         },
 
         "removeButton": {


### PR DESCRIPTION
in the configuration pane

(using default html5 tooltip, do we want some css instead?)
