### PR TITLE
Fix didChangeObjectProperties being fired X times

### DIFF
--- a/core/editing-proxy.js
+++ b/core/editing-proxy.js
@@ -160,11 +160,20 @@ exports.EditingProxy = Target.specialize( /** @lends module:palette/coreediting-
         }
     },
 
+    /**
+     * Whether to dispatch a property change when a property is changed.
+     */
+    propertiesChangeDispatchingEnabled: {
+        value: true
+    },
+
     _dispatchDidChangeObjectProperties: {
         value: function(properties) {
-            this.dispatchEventNamed("didChangeObjectProperties", true, false, {
-                properties: properties
-            });
+            if (this.propertiesChangeDispatchingEnabled) {
+                this.dispatchEventNamed("didChangeObjectProperties", true, false, {
+                    properties: properties
+                });
+            }
         }
     },
 

--- a/test/core/editing-proxy-spec.js
+++ b/test/core/editing-proxy-spec.js
@@ -97,4 +97,46 @@ describe("core/editing-proxy-spec", function () {
         })
     });
 
+    describe("propertiesChangeDispatchingEnabled", function() {
+        beforeEach(function () {
+            serialization = {
+                prototype: exportId,
+                properties: {
+                    foo: "a string",
+                    bar: 42
+                }
+            };
+
+            proxy = new EditingProxy().init(label, serialization, exportId, editingDocument);
+        });
+
+        it("should not dispatch didChangeObjectProperties when propertiesChangeDispatchingEnabled is enabled on setObjectProperty", function() {
+            var listener = {
+                handleEvent: function(){}
+            };
+            spyOn(listener, "handleEvent");
+
+            proxy.addEventListener("didChangeObjectProperties", listener);
+            proxy.propertiesChangeDispatchingEnabled = false;
+            proxy.setObjectProperty("foo", "another string");
+
+            expect(listener.handleEvent.callCount).toBe(0);
+        });
+
+        it("should not dispatch didChangeObjectProperties when propertiesChangeDispatchingEnabled is enabled on setObjectProperties", function() {
+            var listener = {
+                handleEvent: function(){}
+            };
+            spyOn(listener, "handleEvent");
+
+            proxy.addEventListener("didChangeObjectProperties", listener);
+            proxy.propertiesChangeDispatchingEnabled = false;
+            proxy.setObjectProperties({
+                foo: "another string",
+                bar: 1
+            });
+
+            expect(listener.handleEvent.callCount).toBe(0);
+        });
+    });
 });


### PR DESCRIPTION
didChangeObjectProperties was being fired also once per property when
multiple properties were changed via setObjectProperties.
