### PR TITLE
Dispatch didChangeObjectProperty

### DIFF
--- a/core/editing-proxy.js
+++ b/core/editing-proxy.js
@@ -162,13 +162,13 @@ exports.EditingProxy = Target.specialize( /** @lends module:palette/coreediting-
     /**
      * Whether to dispatch a property change when a property is changed.
      */
-    propertiesChangeDispatchingEnabled: {
+    propertyChangeDispatchingEnabled: {
         value: true
     },
 
     _dispatchDidChangeObjectProperties: {
         value: function(properties) {
-            if (this.propertiesChangeDispatchingEnabled) {
+            if (this.propertyChangeDispatchingEnabled) {
                 this.dispatchEventNamed("didChangeObjectProperties", true, false, {
                     properties: properties
                 });
@@ -176,14 +176,23 @@ exports.EditingProxy = Target.specialize( /** @lends module:palette/coreediting-
         }
     },
 
+    _dispatchDidChangeObjectProperty: {
+        value: function(property, value) {
+            if (this.propertyChangeDispatchingEnabled) {
+                this.dispatchEventNamed("didChangeObjectProperty", true, false, {
+                    property: property,
+                    value: value
+                });
+            }
+        }
+    },
+
     setObjectProperty: {
-        value: function (property, value, dispatchPropertiesChange) {
-            var properties = {};
-            properties[property] = value;
+        value: function (property, value, dispatchPropertyChange) {
             this.properties.set(property, value);
-            if (typeof dispatchPropertiesChange === "undefined" ||
-                dispatchPropertiesChange) {
-                this._dispatchDidChangeObjectProperties(properties);
+            if (typeof dispatchPropertyChange === "undefined" ||
+                dispatchPropertyChange) {
+                this._dispatchDidChangeObjectProperty(property, value);
             }
         }
     },

--- a/test/core/editing-proxy-spec.js
+++ b/test/core/editing-proxy-spec.js
@@ -69,19 +69,7 @@ describe("core/editing-proxy-spec", function () {
             proxy = new EditingProxy().init(label, serialization, exportId, editingDocument);
         });
 
-        it("should dispatch when a property is changed", function() {
-            var listener = {
-                handleEvent: function(){}
-            };
-            spyOn(listener, "handleEvent");
-
-            proxy.addEventListener("didChangeObjectProperties", listener);
-            proxy.setObjectProperty("foo", "another string");
-
-            expect(listener.handleEvent.callCount).toBe(1);
-        });
-
-        it("should dispatch a single time when multiple properties are changed", function() {
+        it("should dispatch when properties change", function() {
             var listener = {
                 handleEvent: function(){}
             };
@@ -95,9 +83,24 @@ describe("core/editing-proxy-spec", function () {
 
             expect(listener.handleEvent.callCount).toBe(1);
         });
+
+        it("should not dispatch didChangeObjectProperty", function() {
+            var listener = {
+                handleEvent: function(){}
+            };
+            spyOn(listener, "handleEvent");
+
+            proxy.addEventListener("didChangeObjectProperty", listener);
+            proxy.setObjectProperties({
+                foo: "another string",
+                bar: 1
+            });
+
+            expect(listener.handleEvent).not.toHaveBeenCalled();
+        });
     });
 
-    describe("propertiesChangeDispatchingEnabled", function() {
+    describe("propertyChangeDispatchingEnabled", function() {
         beforeEach(function () {
             serialization = {
                 prototype: exportId,
@@ -110,33 +113,33 @@ describe("core/editing-proxy-spec", function () {
             proxy = new EditingProxy().init(label, serialization, exportId, editingDocument);
         });
 
-        it("should not dispatch didChangeObjectProperties when propertiesChangeDispatchingEnabled is enabled on setObjectProperty", function() {
+        it("should not dispatch didChangeObjectProperty when propertyChangeDispatchingEnabled is enabled ", function() {
             var listener = {
                 handleEvent: function(){}
             };
             spyOn(listener, "handleEvent");
 
-            proxy.addEventListener("didChangeObjectProperties", listener);
-            proxy.propertiesChangeDispatchingEnabled = false;
+            proxy.addEventListener("didChangeObjectProperty", listener);
+            proxy.propertyChangeDispatchingEnabled = false;
             proxy.setObjectProperty("foo", "another string");
 
-            expect(listener.handleEvent.callCount).toBe(0);
+            expect(listener.handleEvent).not.toHaveBeenCalled();
         });
 
-        it("should not dispatch didChangeObjectProperties when propertiesChangeDispatchingEnabled is enabled on setObjectProperties", function() {
+        it("should not dispatch didChangeObjectProperties when propertyChangeDispatchingEnabled is enabled", function() {
             var listener = {
                 handleEvent: function(){}
             };
             spyOn(listener, "handleEvent");
 
             proxy.addEventListener("didChangeObjectProperties", listener);
-            proxy.propertiesChangeDispatchingEnabled = false;
+            proxy.propertyChangeDispatchingEnabled = false;
             proxy.setObjectProperties({
                 foo: "another string",
                 bar: 1
             });
 
-            expect(listener.handleEvent.callCount).toBe(0);
+            expect(listener.handleEvent).not.toHaveBeenCalled();
         });
     });
 });


### PR DESCRIPTION
We used to dispatch all properties under didChangeObjectProperties,
however, it is useful to dispatch two different ones depending on if
we're changing a single property or a bunch of them.
