### PR TITLE
Avoid setting the current document while loading

### DIFF
--- a/core/document-controller.js
+++ b/core/document-controller.js
@@ -84,7 +84,9 @@ exports.DocumentController = Target.specialize({
                 self = this;
 
             if (openDocument) {
-                self._setCurrentDocument(openDocument);
+                if (openDocument.url !== this._latestUrl) {
+                    this._setCurrentDocument(openDocument);
+                }
                 return Promise(openDocument);
             } else {
                 // While opening a new document that is not already the opened,


### PR DESCRIPTION
Setting the document while loading can put the DocumentEditor into an
inconsistent state. I believe this is related to some
dispatchOwnPropertyChanges we're manually firing in the ReelDocument.
