### PR TITLE
Filament Widgets

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "dependencies": {
         "montage": "git://github.com/montagejs/montage.git#892cf7a3627dd118f2d2de7c8e20a13bb42b29ba",
         "matte": "git://github.com/montagejs/matte.git#30ab3c59fa496186a758a2fe7b287b7d5e73a4f2",
-        "mousse": "0.3.0"
+        "mousse": "0.3.0",
+        "filament":"*"
     },
     "devDependencies": {
         "montage-testing": "git://github.com/montagejs/montage-testing.git#3bf86e00f77fd6946454337135be442a9c359aa6",

--- a/ui/inspector/blueprint/property-editor.reel/property-editor.css
+++ b/ui/inspector/blueprint/property-editor.reel/property-editor.css
@@ -68,7 +68,8 @@
     line-height: 1;
 }
 
-.PropertyEditor .matte-InputText {
+.PropertyEditor .matte-InputText,
+.PropertyEditor .InputText {
     display: block;
     width: 100%;
     height: 24px;

--- a/ui/inspector/blueprint/property-value-type/string-property-inspector.reel/string-property-inspector.html
+++ b/ui/inspector/blueprint/property-value-type/string-property-inspector.reel/string-property-inspector.html
@@ -84,7 +84,7 @@
         },
 
         "propertyValue":{
-            "prototype":"matte/ui/input-text.reel",
+            "prototype":"filament/ui/widgets/input-text.reel",
             "properties":{
                 "element":{
                     "#":"propertyValue"


### PR DESCRIPTION
:warning: Not sure about this.

Tried to find a way to use "Filament Widgets" inside the inspector, so I did it the same as for the extensions:
1. Adding `"filament":"*"` to `package.json`
2. And then use `"prototype":"filament/ui/widgets/input-text.reel",` for example

Now.. if Palette has Filament as a dependency, Palette can't really be used for something else anymore, right? Like Plume or so?
